### PR TITLE
인증 api 연동 및 약관동의 flow 추가

### DIFF
--- a/core-data/src/main/java/com/ddd/carssok/core/data/Resource.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/Resource.kt
@@ -1,0 +1,6 @@
+package com.ddd.carssok.core.data
+
+sealed class Resource<T>(val date: T? = null, val message: String? = null) {
+    class Success<T>(data: T?) : Resource<T>(data)
+    class Error<T>(message: String = "", data: T? = null) : Resource<T>(data, message)
+}

--- a/core-data/src/main/java/com/ddd/carssok/core/data/di/OnboardingModule.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/di/OnboardingModule.kt
@@ -2,6 +2,8 @@ package com.ddd.carssok.core.data.di
 
 import com.ddd.carssok.core.data.repository.account.AccountRepository
 import com.ddd.carssok.core.data.repository.account.AccountRepositoryImpl
+import com.ddd.carssok.core.data.repository.agreement.UserAgreementRepository
+import com.ddd.carssok.core.data.repository.agreement.UserAgreementRepositoryImpl
 import com.ddd.carssok.core.data.repository.onboarding.FakeOnBoardingRepositoryImpl
 import com.ddd.carssok.core.data.repository.onboarding.OnBoardingRepository
 import dagger.Binds
@@ -29,5 +31,11 @@ class OnBoardingModule {
         fun bindOnBoardingRepository(
             repository: FakeOnBoardingRepositoryImpl
         ): OnBoardingRepository
+
+        @Binds
+        @ViewModelScoped
+        fun bindUserAgreementRepository(
+            repository: UserAgreementRepositoryImpl
+        ): UserAgreementRepository
     }
 }

--- a/core-data/src/main/java/com/ddd/carssok/core/data/model/UserAgreement.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/model/UserAgreement.kt
@@ -1,0 +1,5 @@
+package com.ddd.carssok.core.data.model
+
+import androidx.annotation.StringRes
+
+data class UserAgreement(val id: Long, @StringRes val messageId: Int, val isChecked: Boolean,@StringRes val link: Int)

--- a/core-data/src/main/java/com/ddd/carssok/core/data/repository/agreement/UserAgreementRepository.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/repository/agreement/UserAgreementRepository.kt
@@ -1,0 +1,34 @@
+package com.ddd.carssok.core.data.repository.agreement
+
+import com.ddd.carssok.core.data.R
+import com.ddd.carssok.core.data.model.UserAgreement
+import com.ddd.carssok.datastore.CarssokDataStore
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+interface UserAgreementRepository {
+    fun getChecklist(): List<UserAgreement>
+    fun checkedUserAgreement(): Flow<Boolean>
+    suspend fun save()
+}
+
+
+class UserAgreementRepositoryImpl @Inject constructor(
+    private val dataStore: CarssokDataStore
+) : UserAgreementRepository {
+    override fun getChecklist(): List<UserAgreement> {
+        return listOf(
+            UserAgreement(1, R.string.agreement_message1, false, R.string.agreement_message1_link),
+            UserAgreement(2, R.string.agreement_message2, false, R.string.agreement_message2_link),
+            UserAgreement(3, R.string.agreement_message3, false, R.string.agreement_message3_link)
+        )
+    }
+
+    override fun checkedUserAgreement(): Flow<Boolean> {
+        return dataStore.checkedUserAgreement()
+    }
+
+    override suspend fun save() {
+        dataStore.saveUserAgreement()
+    }
+}

--- a/core-data/src/main/res/values/strings.xml
+++ b/core-data/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="agreement_message1">(필수) 만 19세 이상입니다.</string>
+    <string name="agreement_message1_link">https://www.naver.com</string>
+    <string name="agreement_message2">(필수) 카쏙 서비스 이용약관 동의</string>
+    <string name="agreement_message2_link">https://www.naver.com</string>
+    <string name="agreement_message3">(필수) 개인정보 처리방침 동의</string>
+    <string name="agreement_message3_link">https://www.naver.com</string>
+</resources>

--- a/core-datastore/src/main/java/com/ddd/carssok/datastore/CarssokDataStore.kt
+++ b/core-datastore/src/main/java/com/ddd/carssok/datastore/CarssokDataStore.kt
@@ -14,6 +14,10 @@ interface CarssokDataStore {
 
     suspend fun updateUserToken(token: String)
 
+    fun checkedUserAgreement(): Flow<Boolean>
+
+    suspend fun saveUserAgreement()
+
     fun clear()
 
 }

--- a/core-datastore/src/main/java/com/ddd/carssok/datastore/CarssokDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/ddd/carssok/datastore/CarssokDataStoreImpl.kt
@@ -2,6 +2,7 @@ package com.ddd.carssok.datastore
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -13,7 +14,7 @@ class CarssokDataStoreImpl @Inject constructor(
 ) : CarssokDataStore {
 
     override fun getUserName(): Flow<String> = carssokPreferences.data.map { preferences ->
-        preferences[KEY_USER_NAME] ?: ""
+        preferences[KEY_USER_NAME].orEmpty()
     }
 
     override suspend fun updateUserName(name: String) {
@@ -32,6 +33,16 @@ class CarssokDataStoreImpl @Inject constructor(
         }
     }
 
+    override fun checkedUserAgreement(): Flow<Boolean> {
+        return carssokPreferences.data.map { it[KEY_USER_AGREEMENT] ?: false }
+    }
+
+    override suspend fun saveUserAgreement() {
+        carssokPreferences.edit { preferences ->
+            preferences[KEY_USER_AGREEMENT] = true
+        }
+    }
+
     override fun clear() {
         // TODO
     }
@@ -40,7 +51,9 @@ class CarssokDataStoreImpl @Inject constructor(
         const val PREFERENCE_DATA_STORE_NAME = "carssok_preferences.pb"
         private val KEY_USER_NAME = "key_user_name".toKey()
         private val KEY_USER_TOKEN = "key_user_token".toKey()
+        private val KEY_USER_AGREEMENT = "key_user_agreement".toBooleanKey()
 
         private fun String.toKey(): Preferences.Key<String> = stringPreferencesKey(this)
+        private fun String.toBooleanKey(): Preferences.Key<Boolean> = booleanPreferencesKey(this)
     }
 }

--- a/core-designsystem/src/main/java/com/ddd/carssok/core/designsystem/component/Checkbox.kt
+++ b/core-designsystem/src/main/java/com/ddd/carssok/core/designsystem/component/Checkbox.kt
@@ -31,8 +31,8 @@ fun CarssockCheckbox(isChecked: Boolean = false, onChangedValue: (Boolean) -> Un
         modifier = Modifier
             .size(16.dp)
             .clickable {
-                rememberCheckState = rememberCheckState.not()
                 onChangedValue.invoke(rememberCheckState.not())
+                rememberCheckState = rememberCheckState.not()
             },
         shape = RoundedCornerShape(99.dp),
         colors = CardDefaults.cardColors(

--- a/core-network/src/main/java/com/ddd/carssok/core/network/ApiResult.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/ApiResult.kt
@@ -1,0 +1,31 @@
+package com.ddd.carssok.core.network
+
+sealed interface ApiResult<T : Any>
+
+class ApiSuccess<T : Any>(val data: T) : ApiResult<T>
+class ApiError<T : Any>(val code: Int, val message: String?) : ApiResult<T>
+class ApiException<T : Any>(val e: Throwable) : ApiResult<T>
+
+suspend fun <T : Any> ApiResult<T>.onSuccess(
+    executable: suspend (T) -> Unit
+): ApiResult<T> = apply {
+    if (this is ApiSuccess<T>) {
+        executable(data)
+    }
+}
+
+suspend fun <T : Any> ApiResult<T>.onError(
+    executable: suspend (code: Int, message: String?) -> Unit
+): ApiResult<T> = apply {
+    if (this is ApiError<T>) {
+        executable(code, message)
+    }
+}
+
+suspend fun <T : Any> ApiResult<T>.onException(
+    executable: suspend (e: Throwable) -> Unit
+): ApiResult<T> = apply {
+    if (this is ApiException<T>) {
+        executable(e)
+    }
+}

--- a/core-network/src/main/java/com/ddd/carssok/core/network/AuthInterceptor.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/AuthInterceptor.kt
@@ -12,9 +12,9 @@ class AuthInterceptor(private val dataStore: CarssokDataStore) : Interceptor {
             dataStore.getUserToken().firstOrNull()
         }
         val originalRequest = chain.request()
-        val requestBuilder = originalRequest.newBuilder()
-            .header("Authorization", "Bearer ${token.orEmpty()}")
-        val request = requestBuilder.build()
+        val request = originalRequest.newBuilder()
+            .addHeader("user-token", token.orEmpty())
+            .build()
         return chain.proceed(request)
     }
 }

--- a/core-network/src/main/java/com/ddd/carssok/core/network/NetworkResultCall.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/NetworkResultCall.kt
@@ -1,0 +1,53 @@
+package com.ddd.carssok.core.network
+
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.HttpException
+import retrofit2.Response
+
+class NetworkResultCall<T : Any>(
+    private val proxy: Call<T>
+) : Call<ApiResult<T>> {
+
+    override fun enqueue(callback: Callback<ApiResult<T>>) {
+        proxy.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                val networkResult = handleApi { response }
+                callback.onResponse(this@NetworkResultCall, Response.success(networkResult))
+            }
+
+            override fun onFailure(call: Call<T>, t: Throwable) {
+                val networkResult = ApiException<T>(t)
+                callback.onResponse(this@NetworkResultCall, Response.success(networkResult))
+            }
+        })
+    }
+
+    override fun execute(): Response<ApiResult<T>> = throw NotImplementedError()
+    override fun clone(): Call<ApiResult<T>> = NetworkResultCall(proxy.clone())
+    override fun request(): Request = proxy.request()
+    override fun timeout(): Timeout = proxy.timeout()
+    override fun isExecuted(): Boolean = proxy.isExecuted
+    override fun isCanceled(): Boolean = proxy.isCanceled
+    override fun cancel() = proxy.cancel()
+}
+
+private fun <T : Any> handleApi(
+    execute: () -> Response<T>
+): ApiResult<T> {
+    return try {
+        val response = execute()
+        val body = response.body()
+        if (response.isSuccessful && body != null) {
+            ApiSuccess(body)
+        } else {
+            ApiError(code = response.code(), message = response.message())
+        }
+    } catch (e: HttpException) {
+        ApiError(code = e.code(), message = e.message())
+    } catch (e: Throwable) {
+        ApiException(e)
+    }
+}

--- a/core-network/src/main/java/com/ddd/carssok/core/network/NetworkResultCallAdapter.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/NetworkResultCallAdapter.kt
@@ -1,0 +1,12 @@
+package com.ddd.carssok.core.network
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class NetworkResultCallAdapter(private val resultType: Type) : CallAdapter<Type, Call<ApiResult<Type>>> {
+
+    override fun responseType(): Type = resultType
+
+    override fun adapt(call: Call<Type>): Call<ApiResult<Type>> = NetworkResultCall(call)
+}

--- a/core-network/src/main/java/com/ddd/carssok/core/network/NetworkResultCallAdapterFactory.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/NetworkResultCallAdapterFactory.kt
@@ -1,0 +1,28 @@
+package com.ddd.carssok.core.network
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class NetworkResultCallAdapterFactory : CallAdapter.Factory() {
+
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+
+        val callType = getParameterUpperBound(0, returnType as ParameterizedType)
+        if (getRawType(callType) != ApiResult::class.java) {
+            return null
+        }
+
+        val resultType = getParameterUpperBound(0, callType as ParameterizedType)
+        return NetworkResultCallAdapter(resultType)
+    }
+}

--- a/core-network/src/main/java/com/ddd/carssok/core/network/api/AuthApi.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/api/AuthApi.kt
@@ -1,15 +1,18 @@
 package com.ddd.carssok.core.network.api
 
+import com.ddd.carssok.core.network.ApiResult
 import com.ddd.carssok.core.network.model.AuthRequestBody
+import com.ddd.carssok.core.network.model.BaseModel
 import com.ddd.carssok.core.network.model.UserTokenResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthApi {
     @POST("/auth")
-    suspend fun requestAuth(@Body authRequest: AuthRequestBody): UserTokenResponse
+    suspend fun requestAuth(@Body authRequest: AuthRequestBody): ApiResult<BaseModel<UserTokenResponse>>
 
     @GET("/auth")
-    suspend fun getUserToken() : UserTokenResponse
+    suspend fun getUserToken(@Header("device-id") deviceId: String): ApiResult<BaseModel<UserTokenResponse>>
 }

--- a/core-network/src/main/java/com/ddd/carssok/core/network/di/NetworkModule.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.ddd.carssok.core.network.di
 
 import com.ddd.carssok.core.network.AuthInterceptor
 import com.ddd.carssok.core.network.BuildConfig
+import com.ddd.carssok.core.network.NetworkResultCallAdapterFactory
 import com.ddd.carssok.datastore.CarssokDataStore
 import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
@@ -18,6 +19,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+
+    @Singleton
+    @Provides
+    fun provideNetworkResultCallAdapterFactory() = NetworkResultCallAdapterFactory()
 
     @Singleton
     @Provides
@@ -42,11 +47,15 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        networkResultCallAdapterFactory: NetworkResultCallAdapterFactory
+    ): Retrofit {
         return Retrofit.Builder()
             .client(okHttpClient)
             .baseUrl(BuildConfig.CARSSOK_URL)
             .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(networkResultCallAdapterFactory)
             .build()
     }
 }

--- a/core-network/src/main/java/com/ddd/carssok/core/network/model/BaseModel.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/model/BaseModel.kt
@@ -1,0 +1,9 @@
+package com.ddd.carssok.core.network.model
+
+import com.google.gson.annotations.SerializedName
+
+data class BaseModel<T>(
+    @SerializedName("data") val model: T,
+    @SerializedName("statusCode") val statusCode: Int,
+    @SerializedName("message") val message: String,
+)

--- a/feature/home/src/main/java/com/ddd/carssok/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ddd/carssok/feature/home/HomeViewModel.kt
@@ -11,24 +11,22 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val accountRepository: AccountRepository
+    private val accountRepository: AccountRepository,
 ) : ViewModel() {
 
     sealed class Event {
-        data class CheckedCarssokUser(val isCarssokUser:Boolean) : Event()
+        data class CheckedCarssokUser(val isCarssokUser: Boolean) : Event()
     }
 
     private val _event = MutableSharedFlow<Event>()
     val event = _event.asSharedFlow()
 
     init {
-        isCarssokUser()
+        checkedCarssokUser()
     }
 
-    private fun isCarssokUser() = viewModelScope.launch {
-        accountRepository.checkedCarssokuser()
-        val fakeValue = false
-
-        _event.emit(Event.CheckedCarssokUser(fakeValue))
+    private fun checkedCarssokUser() = viewModelScope.launch {
+        val result = accountRepository.checkedCarssokuser()
+        _event.emit(Event.CheckedCarssokUser( false))
     }
 }

--- a/feature/home/src/main/java/com/ddd/carssok/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ddd/carssok/feature/home/HomeViewModel.kt
@@ -26,7 +26,7 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun checkedCarssokUser() = viewModelScope.launch {
-        val result = accountRepository.checkedCarssokuser()
-        _event.emit(Event.CheckedCarssokUser( false))
+        val result = accountRepository.checkedCarssokuser().date ?: false
+        _event.emit(Event.CheckedCarssokUser(result))
     }
 }

--- a/feature/home/src/main/java/com/ddd/carssok/feature/home/navi/HomeDestination.kt
+++ b/feature/home/src/main/java/com/ddd/carssok/feature/home/navi/HomeDestination.kt
@@ -14,7 +14,7 @@ object HomeDestination : CarssokNavigationDestination {
 }
 
 fun NavGraphBuilder.toHomeGraph(
-    navController: NavHostController,
+    navController: NavHostController
 ) {
     composable(
         route = HomeDestination.route

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/agreement/OnBoardingUserAgreementScreen.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/agreement/OnBoardingUserAgreementScreen.kt
@@ -1,0 +1,116 @@
+package com.ddd.carssok.feature.onboarding.agreement
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.ddd.carssok.core.data.model.UserAgreement
+import com.ddd.carssok.core.designsystem.TypoStyle
+import com.ddd.carssok.core.designsystem.component.CarssockCheckbox
+import com.ddd.carssok.core.designsystem.component.CarssokButton
+import com.ddd.carssok.core.designsystem.component.TypoText
+import com.ddd.carssok.feature.onboarding.R
+
+
+@Composable
+fun OnBoardingUserAgreementRoute(
+    viewModel: OnBoardingUserAgreementViewModel = hiltViewModel(),
+    done: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+    OnBoardingUserAgreementScreen(state.checkList, state.buttonEnabled, viewModel::onChecked, onClickedSave = {
+        viewModel.onClickedSave()
+        done()
+    })
+}
+
+@Composable
+fun OnBoardingUserAgreementScreen(
+    checkList: List<UserAgreement>,
+    buttonEnabled: Boolean,
+    onChangedCheckBox: (Long, Boolean) -> Unit,
+    onClickedSave: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .background(color = colorResource(id = com.ddd.carssok.core.designsystem.R.color.primary_bg))
+            .padding(horizontal = 24.dp, vertical = 52.dp)
+            .fillMaxSize()
+    ) {
+        OnBoardingUserAgreementHeader()
+        OnBoardingUserAgreementCheckbox(checkList, onChangedCheckBox)
+        Box(modifier = Modifier.fillMaxHeight(), contentAlignment = Alignment.BottomCenter) {
+            CarssokButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                isEnabled = buttonEnabled,
+                titleRes = R.string.on_boarding_user_agreement_ok,
+                onClicked = onClickedSave
+            )
+        }
+    }
+}
+
+@Composable
+fun OnBoardingUserAgreementHeader() {
+    TypoText(
+        text = stringResource(id = R.string.on_boarding_title),
+        typoStyle = TypoStyle.DISPLAY_SMALL_24,
+        color = colorResource(id = com.ddd.carssok.core.designsystem.R.color.primary_text)
+    )
+    TypoText(
+        text = stringResource(id = R.string.on_boarding_subtitle),
+        typoStyle = TypoStyle.HEADLINE_X_SMALL_14,
+        color = colorResource(id = com.ddd.carssok.core.designsystem.R.color.primary_text)
+    )
+}
+
+@Composable
+fun OnBoardingUserAgreementCheckbox(checkList: List<UserAgreement>, onChangedCheckBox: (Long, Boolean) -> Unit) {
+    TypoText(
+        text = stringResource(id = R.string.on_boarding_require_check),
+        typoStyle = TypoStyle.HEADLINE_X_SMALL_14,
+        modifier = Modifier.padding(top = 44.dp)
+    )
+    LazyColumn(modifier = Modifier.padding()) {
+        itemsIndexed(checkList, key = { _: Int, item: UserAgreement -> item.id }) { _, item ->
+            Row(modifier = Modifier.height(48.dp), verticalAlignment = Alignment.CenterVertically) {
+                CarssockCheckbox(isChecked = item.isChecked, onChangedValue = {
+                    onChangedCheckBox(item.id, it)
+                })
+                Spacer(modifier = Modifier.width(14.dp))
+                TypoText(
+                    text = stringResource(id = item.messageId), typoStyle = TypoStyle.HEADLINE_SMALL_16
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun OnBoardingUserAgreementRoutePreview() {
+    OnBoardingUserAgreementRoute {
+
+    }
+}

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/agreement/OnBoardingUserAgreementViewModel.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/agreement/OnBoardingUserAgreementViewModel.kt
@@ -1,0 +1,51 @@
+package com.ddd.carssok.feature.onboarding.agreement
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ddd.carssok.core.data.model.UserAgreement
+import com.ddd.carssok.core.data.repository.agreement.UserAgreementRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OnBoardingUserAgreementViewModel @Inject constructor(
+    private val userAgreementRepository: UserAgreementRepository
+) : ViewModel() {
+
+    data class UiState(
+        val checkList: List<UserAgreement> = emptyList(),
+        val buttonEnabled: Boolean = false
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val checkList = userAgreementRepository.getChecklist()
+            _uiState.update { it.copy(checkList = checkList) }
+        }
+    }
+
+    fun onChecked(id: Long, isChecked: Boolean) {
+        val currentList = _uiState.value.checkList.toMutableList().apply {
+            val index = indexOfFirst { it.id == id }
+            this[index] = this[index].copy(isChecked = isChecked)
+        }
+
+        val isButtonEnabled = currentList.any { it.isChecked }
+        _uiState.update { it.copy(checkList = currentList, buttonEnabled = isButtonEnabled) }
+    }
+
+    fun onClickedLink() {
+
+    }
+
+    fun onClickedSave() = viewModelScope.launch {
+        userAgreementRepository.save()
+    }
+}

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/brand/OnBoardingBrandScreen.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/brand/OnBoardingBrandScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -38,15 +39,23 @@ import com.ddd.carssok.core.designsystem.component.CarssokButton
 import com.ddd.carssok.core.designsystem.component.TypoText
 import com.ddd.carssok.core.model.CarBrand
 import com.ddd.carssok.feature.onboarding.R
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun OnBoardingBrandRoute(
+    needAgreement: () -> Unit,
     onDone: () -> Unit,
     onBackPressed: () -> Unit,
     viewModel: OnBoardingBrandViewModel = hiltViewModel()
 ) {
+    val state by viewModel.uiState.collectAsState()
+
     OnBoardingBrandScreen(
-        viewModel = viewModel,
+        state = state,
+        event = viewModel.event,
+        needAgreement = needAgreement,
         onChecked = { id, isChecked ->
             viewModel.onCheckedBrandCard(id, isChecked)
         },
@@ -57,11 +66,20 @@ fun OnBoardingBrandRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OnBoardingBrandScreen(
-    viewModel: OnBoardingBrandViewModel,
+    state: OnBoardingBrandViewModel.UiState,
+    event: SharedFlow<OnBoardingBrandViewModel.Event>,
+    needAgreement: () -> Unit,
     onChecked: (Long, Boolean) -> Unit,
-    onClickedNextButton:() -> Unit,
+    onClickedNextButton: () -> Unit,
 ) {
-    val state by viewModel.uiState.collectAsState()
+    LaunchedEffect(Unit) {
+        event.collectLatest {
+            if (it is OnBoardingBrandViewModel.Event.NeedAgreement) {
+                needAgreement()
+            }
+        }
+    }
+
     Scaffold(
         containerColor = colorResource(id = com.ddd.carssok.core.designsystem.R.color.primary_bg),
         floatingActionButton = {
@@ -190,6 +208,7 @@ fun CountryBrandCarItem(
 @Composable
 fun OnBoardingBrandScreenPreview() {
     OnBoardingBrandRoute(
+        needAgreement = {},
         onDone = {},
         onBackPressed = {}
     )

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/brand/OnBoardingBrandViewModel.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/brand/OnBoardingBrandViewModel.kt
@@ -3,17 +3,22 @@ package com.ddd.carssok.feature.onboarding.brand
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ddd.carssok.core.data.repository.account.AccountRepository
+import com.ddd.carssok.core.data.repository.agreement.UserAgreementRepository
 import com.ddd.carssok.core.model.CarBrand
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class OnBoardingBrandViewModel @Inject constructor(
-    private val authRepository: AccountRepository
+    private val authRepository: AccountRepository,
+    private val userAgreementRepository: UserAgreementRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
@@ -23,17 +28,31 @@ class OnBoardingBrandViewModel @Inject constructor(
         val nextButtonEnabled: Boolean = true
     )
 
+    sealed interface Event {
+        object NeedAgreement : Event
+    }
+
+    private val _event = MutableSharedFlow<Event>()
+    val event = _event.asSharedFlow()
+
     init {
-        val dummy =
-            listOf(
-                CarBrand(1, "기아", false),
-                CarBrand(2, "현대", false),
-                CarBrand(3, "르노", false),
-                CarBrand(4, "쌍용", false),
-                CarBrand(5, "제네시스", false),
-                CarBrand(6, "제네시스", false)
-            )
-        _uiState.update { it.copy(brandItems = dummy) }
+        viewModelScope.launch {
+            val isPass = userAgreementRepository.checkedUserAgreement().first()
+            if (isPass.not()) {
+                _event.emit(Event.NeedAgreement)
+            } else {
+                val dummy =
+                    listOf(
+                        CarBrand(1, "기아", false),
+                        CarBrand(2, "현대", false),
+                        CarBrand(3, "르노", false),
+                        CarBrand(4, "쌍용", false),
+                        CarBrand(5, "제네시스", false),
+                        CarBrand(6, "제네시스", false)
+                    )
+                _uiState.update { it.copy(brandItems = dummy) }
+            }
+        }
 
         viewModelScope.launch {
             kotlin.runCatching {

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/fuel/OnBoardingFuelScreen.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/fuel/OnBoardingFuelScreen.kt
@@ -20,8 +20,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -43,17 +46,24 @@ import com.ddd.carssok.core.designsystem.component.CarssokButton
 import com.ddd.carssok.core.designsystem.component.Chip
 import com.ddd.carssok.core.designsystem.component.TypoText
 import com.ddd.carssok.feature.onboarding.R
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun OnBoardingFuelRoute(
-    onClickedDone: () -> Unit,
+    onOnBoardingDone: () -> Unit,
     onBackPressed: () -> Unit,
     viewModel: OnBoardingFuelViewModel = hiltViewModel()
 ) {
+    LaunchedEffect(Unit) {
+        viewModel.event.collectLatest { event ->
+            if (event is OnBoardingFuelViewModel.Event.OnSuccessSignup) {
+                onOnBoardingDone.invoke()
+            }
+        }
+    }
     OnBoardingFuelScreen(
         onClickedDone = {
             viewModel.onClickedDone()
-            onClickedDone()
         },
         onBackPressed = onBackPressed,
         onClickedChipFuel = viewModel::onClickedFilterFuel,
@@ -188,7 +198,7 @@ fun OnBoardingFuelCarInfo(carName: String, carImageUrl: String) {
 @Composable
 fun OnBoardingFuelScreenPreview() {
     OnBoardingFuelRoute(
-        onClickedDone = {},
+        onOnBoardingDone = {},
         onBackPressed = {}
     )
 }

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/fuel/OnBoardingFuelViewModel.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/fuel/OnBoardingFuelViewModel.kt
@@ -1,11 +1,17 @@
 package com.ddd.carssok.feature.onboarding.fuel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ddd.carssok.core.data.Resource
 import com.ddd.carssok.core.data.repository.HomeRepositoryImpl
+import com.ddd.carssok.core.data.repository.account.AccountRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // 임시
@@ -19,16 +25,25 @@ enum class FuelType(val koreanName: String) {
 }
 
 @HiltViewModel
-class OnBoardingFuelViewModel @Inject constructor(private val repository: HomeRepositoryImpl) : ViewModel() {
-
+class OnBoardingFuelViewModel @Inject constructor(
+    private val repository: HomeRepositoryImpl,
+    private val accountRepository: AccountRepository
+) : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
+
+    private val _event = MutableSharedFlow<Event>()
+    val event = _event.asSharedFlow()
 
     data class UiState(
         val carName: String = "",
         val carImageUrl: String = "",
         val fuelList: List<FuelType> = emptyList()
     )
+
+    sealed interface Event {
+        object OnSuccessSignup : Event
+    }
 
     init {
         _uiState.update { it.copy(carName = "아반떼 하이브리드(CN7)", fuelList = FuelType.values().toList()) }
@@ -39,7 +54,12 @@ class OnBoardingFuelViewModel @Inject constructor(private val repository: HomeRe
 
     }
 
-    fun onClickedDone() {
-        repository.needShowOnBoarding = false
+    fun onClickedDone() = viewModelScope.launch {
+        val result = accountRepository.updateRemoteUserToken()
+        if (result is Resource.Success) {
+            _event.emit(Event.OnSuccessSignup)
+        } else {
+            // show toast
+        }
     }
 }

--- a/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/navi/OnBoardingDestination.kt
+++ b/feature/onboarding/src/main/java/com/ddd/carssok/feature/onboarding/navi/OnBoardingDestination.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.ddd.carssok.core.navigator.CarssokNavigationDestination
+import com.ddd.carssok.feature.onboarding.agreement.OnBoardingUserAgreementRoute
 import com.ddd.carssok.feature.onboarding.brand.OnBoardingBrandRoute
 import com.ddd.carssok.feature.onboarding.fuel.OnBoardingFuelRoute
 import com.ddd.carssok.feature.onboarding.model.OnBoardingModelRoute
@@ -29,6 +30,11 @@ private object OnBoardingFuelDestination : CarssokNavigationDestination {
     override val destination: String = "onboarding_fuel_destination"
 }
 
+object OnBoardingAgreementDestination : CarssokNavigationDestination {
+    override val route: String = "onboarding_agreement_route"
+    override val destination: String = "onboarding_agreement_destination"
+}
+
 fun NavGraphBuilder.toOnBoardingGraph(
     navController: NavHostController,
     onOnBoardingDone: () -> Unit,
@@ -38,10 +44,20 @@ fun NavGraphBuilder.toOnBoardingGraph(
         startDestination = OnBoardingBrandDestination.route,
         route = OnBoardingDestination.route
     ) {
+
+        composable(OnBoardingAgreementDestination.route) {
+            OnBoardingUserAgreementRoute {
+                navController.navigate(OnBoardingBrandDestination.route)
+            }
+        }
+
         composable(
             route = OnBoardingBrandDestination.route,
         ) {
             OnBoardingBrandRoute(
+                needAgreement = {
+                    navController.navigate(OnBoardingAgreementDestination.route)
+                },
                 onDone = {
                     navController.navigate(OnBoardingModelDestination.route)
                 },
@@ -64,7 +80,7 @@ fun NavGraphBuilder.toOnBoardingGraph(
             route = OnBoardingFuelDestination.route,
         ) {
             OnBoardingFuelRoute(
-                onClickedDone = onOnBoardingDone,
+                onOnBoardingDone = onOnBoardingDone,
                 onBackPressed = onBackPressed
             )
         }

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -2,6 +2,13 @@
 <resources>
     <string name="button_title_next">다음</string>
 
+    <!--이용약관-->
+    <string name="on_boarding_user_agreement_ok">확인</string>
+    <string name="on_boarding_user_agreement_save">저장하기</string>
+    <string name="on_boarding_require_check">필수 동의 항목</string>
+    <string name="on_boarding_title">카쏙에 처음 이시군요!\n이용약관에 동의해주세요.</string>
+    <string name="on_boarding_subtitle">약관동의없이 이용 제한될 수 있습니다.</string>
+
     <!--온보딩 브랜드 선택-->
     <string name="on_boarding_select_brand_next">다음</string>
     <string name="on_boarding_select_brand_title">가지고 계신 차량의\n제조사는 무엇인가요?</string>


### PR DESCRIPTION
기억이 저도 가물가물한데 네트워크 관련 만든거 설명드린 부분 구현된 내용입니다 ㅎㅎ
- api 공통 모델 및 wrapper class 추가, interceptor 추가(헤더 토큰)
- 계정 등록 및 가입여부 관련 api 추가
- 약관동의 flow 추가(온보딩 처음 vm에서 체크 이후 navigate방식)
- 이후 다른쪽 작업한건 이거 머지 되면 rebase쳐서 다시 올릴게요ㅎㅎ