### PR TITLE
[#42] 주행기록하기 API 연동

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(Dep.Modules.CORE_MODEL))
     implementation(project(Dep.Modules.CORE_DATASTORE))
     implementation(project(Dep.Modules.CORE_NETWORK))
 

--- a/core-data/src/main/java/com/ddd/carssok/core/data/di/RecordModule.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/di/RecordModule.kt
@@ -1,0 +1,36 @@
+package com.ddd.carssok.core.data.di
+
+import com.ddd.carssok.core.data.repository.record.drive.RecordDriveRepository
+import com.ddd.carssok.core.data.repository.record.drive.RecordDriveRepositoryImpl
+import com.ddd.carssok.core.data.source.record.drive.RecordDriveLocalDataSource
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module(
+    includes = [
+        RecordModule.RecordBindsModule::class
+    ]
+)
+@InstallIn(ViewModelComponent::class)
+class RecordModule {
+
+    @Provides
+    @ViewModelScoped
+    fun provideRecordDriveLocalDataSource(): RecordDriveLocalDataSource = RecordDriveLocalDataSource()
+
+    @Module
+    @InstallIn(ViewModelComponent::class)
+    interface RecordBindsModule {
+
+        @Binds
+        @ViewModelScoped
+        fun bindRecordDriveRepository(
+            repository: RecordDriveRepositoryImpl
+        ): RecordDriveRepository
+
+    }
+}

--- a/core-data/src/main/java/com/ddd/carssok/core/data/repository/record/drive/RecordDriveMapper.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/repository/record/drive/RecordDriveMapper.kt
@@ -1,0 +1,11 @@
+package com.ddd.carssok.core.data.repository.record.drive
+
+import com.ddd.carssok.core.model.record.drive.DriveHistoryEntity
+import com.ddd.carssok.core.network.model.record.DriveHistoryResponse
+
+
+fun DriveHistoryResponse.toEntity() = DriveHistoryEntity(
+    id = id ?: 0,
+    date = date.orEmpty(),
+    distance = distance ?: 0
+)

--- a/core-data/src/main/java/com/ddd/carssok/core/data/repository/record/drive/RecordDriveRepository.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/repository/record/drive/RecordDriveRepository.kt
@@ -1,0 +1,82 @@
+package com.ddd.carssok.core.data.repository.record.drive
+
+import com.ddd.carssok.IoDispatcher
+import com.ddd.carssok.core.data.Resource
+import com.ddd.carssok.core.data.source.record.drive.RecordDriveLocalDataSource
+import com.ddd.carssok.core.model.record.drive.DriveHistoryEntity
+import com.ddd.carssok.core.network.ApiSuccess
+import com.ddd.carssok.core.network.api.RecordApi
+import com.ddd.carssok.core.network.model.record.RecordDriveRequest
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface RecordDriveRepository {
+
+    suspend fun getTotalDistance(): Resource<Int>
+
+    suspend fun getAllHistory(): Resource<List<DriveHistoryEntity>>
+
+    suspend fun record(date: String, distance: Int): Resource<Boolean>
+
+    suspend fun delete(id: Int) : Resource<Boolean>
+}
+
+class RecordDriveRepositoryImpl @Inject constructor(
+    private val recordApi: RecordApi,
+    private val localDataSource: RecordDriveLocalDataSource,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : RecordDriveRepository {
+
+    override suspend fun getTotalDistance(): Resource<Int> = withContext(ioDispatcher) {
+        return@withContext when (val result = recordApi.getTotalDriveDistance()) {
+            is ApiSuccess -> {
+                Resource.Success(data = result.data.model.totalDistance ?: 0)
+            }
+            else -> Resource.Error()
+        }
+    }
+
+    override suspend fun getAllHistory(): Resource<List<DriveHistoryEntity>> = withContext(ioDispatcher) {
+        return@withContext localDataSource.getHistoryList()?.let {
+            Resource.Success(data = it)
+        } ?: run {
+            when (val result = recordApi.getAllDrive()) {
+                is ApiSuccess -> {
+                    val historyList = result.data.model.map { it.toEntity() }.also {
+                        localDataSource.setHistoryList(it)
+                    }
+                    Resource.Success(data = historyList)
+                }
+                else -> Resource.Error()
+            }
+        }
+    }
+
+    override suspend fun record(date: String, distance: Int): Resource<Boolean> = withContext(ioDispatcher) {
+        val request = RecordDriveRequest(
+            eventAt = date,
+            distance = distance
+        )
+        return@withContext when (val result = recordApi.recordDrive(request)) {
+            is ApiSuccess -> {
+                Resource.Success(data = result.data.model.status?.isNotBlank() ?: false)
+            }
+            else -> Resource.Error()
+        }
+    }
+
+    override suspend fun delete(id: Int): Resource<Boolean> = withContext(ioDispatcher) {
+        return@withContext when (val result = recordApi.deleteDrive(id = id)) {
+            is ApiSuccess -> {
+                val status = result.data.model.status?.isNotBlank() ?: false
+                if (status) {
+                    localDataSource.deleteHistory(id)
+                }
+                Resource.Success(data = status)
+            }
+            else -> Resource.Error()
+        }
+    }
+
+}

--- a/core-data/src/main/java/com/ddd/carssok/core/data/source/record/drive/RecordDriveLocalDataSource.kt
+++ b/core-data/src/main/java/com/ddd/carssok/core/data/source/record/drive/RecordDriveLocalDataSource.kt
@@ -1,0 +1,21 @@
+package com.ddd.carssok.core.data.source.record.drive
+
+import com.ddd.carssok.core.model.record.drive.DriveHistoryEntity
+import javax.inject.Inject
+
+class RecordDriveLocalDataSource @Inject constructor() {
+
+    private var historyList: MutableList<DriveHistoryEntity>? = null
+
+    fun getHistoryList(): List<DriveHistoryEntity>? {
+        return historyList
+    }
+
+    fun setHistoryList(list: List<DriveHistoryEntity>) {
+        historyList = list.toMutableList()
+    }
+
+    fun deleteHistory(id: Int): Boolean {
+        return historyList?.removeIf { it.id == id } ?: false
+    }
+}

--- a/core-model/src/main/java/com/ddd/carssok/core/model/record/drive/RecordDriveModel.kt
+++ b/core-model/src/main/java/com/ddd/carssok/core/model/record/drive/RecordDriveModel.kt
@@ -1,0 +1,7 @@
+package com.ddd.carssok.core.model.record.drive
+
+data class DriveHistoryEntity(
+    val id: Int,
+    val date: String,
+    val distance: Int,
+)

--- a/core-network/src/main/java/com/ddd/carssok/core/network/api/RecordApi.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/api/RecordApi.kt
@@ -1,0 +1,41 @@
+package com.ddd.carssok.core.network.api
+
+import com.ddd.carssok.core.network.ApiResult
+import com.ddd.carssok.core.network.model.BaseModel
+import com.ddd.carssok.core.network.model.record.DeleteDriveResponse
+import com.ddd.carssok.core.network.model.record.DriveHistoryResponse
+import com.ddd.carssok.core.network.model.record.RecordDriveRequest
+import com.ddd.carssok.core.network.model.record.RecordDriveResponse
+import com.ddd.carssok.core.network.model.record.TotalDriveDistanceResponse
+import com.ddd.carssok.core.network.model.record.UpdateDriveResponse
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface RecordApi {
+
+    @GET("/record/runs")
+    suspend fun getAllDrive(): ApiResult<BaseModel<List<DriveHistoryResponse>>>
+
+    @GET("/record/runs/total-distance")
+    suspend fun getTotalDriveDistance(): ApiResult<BaseModel<TotalDriveDistanceResponse>>
+
+    @POST("/record/runs")
+    suspend fun recordDrive(
+        @Body request: RecordDriveRequest
+    ): ApiResult<BaseModel<RecordDriveResponse>>
+
+    @DELETE("/record/runs/{id}")
+    suspend fun deleteDrive(
+        @Path("id") id: Int
+    ): ApiResult<BaseModel<DeleteDriveResponse>>
+
+    @PUT("record/runs/{id}")
+    suspend fun updateDrive(
+        @Path("id") id: String,
+        @Body request: RecordDriveRequest
+    ): ApiResult<BaseModel<UpdateDriveResponse>>
+}

--- a/core-network/src/main/java/com/ddd/carssok/core/network/di/ApiModule.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/di/ApiModule.kt
@@ -1,6 +1,7 @@
 package com.ddd.carssok.core.network.di
 
 import com.ddd.carssok.core.network.api.AuthApi
+import com.ddd.carssok.core.network.api.RecordApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,4 +16,8 @@ object ApiModule {
     @Singleton
     @Provides
     fun provideAuthApi(retrofit: Retrofit): AuthApi = retrofit.create(AuthApi::class.java)
+
+    @Singleton
+    @Provides
+    fun provideRecordApi(retrofit: Retrofit): RecordApi = retrofit.create(RecordApi::class.java)
 }

--- a/core-network/src/main/java/com/ddd/carssok/core/network/model/record/RecordDriveRequest.kt.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/model/record/RecordDriveRequest.kt.kt
@@ -1,0 +1,9 @@
+package com.ddd.carssok.core.network.model.record
+
+import com.google.gson.annotations.SerializedName
+
+// 주행기록 등록
+data class RecordDriveRequest(
+    @SerializedName("eventedAt") val eventAt: String,
+    @SerializedName("distance") val distance: Int,
+)

--- a/core-network/src/main/java/com/ddd/carssok/core/network/model/record/RecordDriveResponse.kt
+++ b/core-network/src/main/java/com/ddd/carssok/core/network/model/record/RecordDriveResponse.kt
@@ -1,0 +1,31 @@
+package com.ddd.carssok.core.network.model.record
+
+import com.google.gson.annotations.SerializedName
+
+// 주행기록 조회
+data class DriveHistoryResponse(
+    @SerializedName("id") val id: Int?,
+    @SerializedName("date") val date: String?,
+    @SerializedName("distance") val distance: Int?,
+)
+
+// 전체 주행거리 조회
+data class TotalDriveDistanceResponse(
+    @SerializedName("distance") val totalDistance: Int?,
+)
+
+// 주행기록 등록
+data class RecordDriveResponse(
+    @SerializedName("id") val id: Int?,
+    @SerializedName("status") val status: String?,
+)
+
+// 주행기록 삭제
+data class DeleteDriveResponse(
+    @SerializedName("status") val status: String?,
+)
+
+// 주행기록 수정
+data class UpdateDriveResponse(
+    @SerializedName("status") val status: String?,
+)

--- a/feature/record/build.gradle.kts
+++ b/feature/record/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(Dep.Modules.CORE_DATA))
+    implementation(project(Dep.Modules.CORE_MODEL))
     implementation(project(Dep.Modules.CORE_NAVIGATOR))
     implementation(project(Dep.Modules.CORE_DESIGN_SYSTEM))
 }

--- a/feature/record/src/main/java/com/ddd/carssok/feature/record/drive/RecordDriveViewModel.kt
+++ b/feature/record/src/main/java/com/ddd/carssok/feature/record/drive/RecordDriveViewModel.kt
@@ -1,25 +1,80 @@
 package com.ddd.carssok.feature.record.drive
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ddd.carssok.core.data.repository.record.drive.RecordDriveRepository
+import com.ddd.carssok.feature.record.utils.DateUtils
+import com.ddd.carssok.feature.record.utils.DateUtils.toDateString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class RecordDriveViewModel @Inject constructor(
-
+    private val repository: RecordDriveRepository
 ): ViewModel() {
 
-    private val _mileageState = MutableStateFlow<String>("")
-    val mileageState = _mileageState.asStateFlow()
+    private val _uiState = MutableStateFlow(RecordDriveUiState.EMPTY)
+    val uiState = _uiState.asStateFlow()
 
-    fun updateMileage(mileage: String) {
-        _mileageState.update { mileage }
+    init {
+        init()
     }
 
-    fun saveDriveRecord() {
+    private fun init() = viewModelScope.launch {
+        val totalDistance = repository.getTotalDistance().date
+        _uiState.update {
+            it.copy(
+                totalDistance = totalDistance ?: 0,
+                date = System.currentTimeMillis().toDateString(format = null),
+                distance = "",
+            )
+        }
+    }
 
+    fun updateDistance(distance: String) {
+        _uiState.update {
+            it.copy(
+                distance = distance
+            )
+        }
+    }
+
+    fun updateDate(date: String) {
+        _uiState.update {
+            it.copy(
+                date = date
+            )
+        }
+    }
+
+    fun recordDriveHistory() = viewModelScope.launch {
+        repository.record(
+            date = _uiState.value.date,
+            distance = _uiState.value.distance.toInt(),
+        )
+
+        init()
+    }
+}
+
+data class RecordDriveUiState(
+    val totalDistance: Int,
+    val date: String,
+    val distance: String
+) {
+    val year: Int = DateUtils.getYear(date, null)
+    val month: Int = DateUtils.getMonth(date, null)
+    val day: Int = DateUtils.getDay(date, null)
+
+    companion object {
+        val EMPTY = RecordDriveUiState(
+            totalDistance = 0,
+            date = System.currentTimeMillis().toDateString(null),
+            distance = "",
+        )
     }
 }

--- a/feature/record/src/main/java/com/ddd/carssok/feature/record/utils/DateUtils.kt
+++ b/feature/record/src/main/java/com/ddd/carssok/feature/record/utils/DateUtils.kt
@@ -1,0 +1,116 @@
+package com.ddd.carssok.feature.record.utils
+
+import androidx.annotation.StringRes
+import com.ddd.carssok.feature.record.R
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+
+object DateUtils {
+    private const val DEFAULT_FORMAT_DATE_WITHOUT_TIME = "yyyy-MM-dd"
+
+    enum class WeekDay {
+        MON, TUE, WED, THU, FRI, SAT, SUN
+    }
+
+    fun Long.toDateString(format: String?): String {
+        return try {
+            Date(this).formatDate(format)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            this.toString()
+        }
+    }
+
+    fun getPreviousMonth(month: Int): Int {
+        val c = Calendar.getInstance().apply {
+            set(Calendar.MONTH, month - 1) // 0 for January
+            add(Calendar.MONTH, -1)
+        }
+        return getMonth(c.time)
+    }
+
+    fun getNextMonth(month: Int): Int {
+        val c = Calendar.getInstance().apply {
+            set(Calendar.MONTH, month - 1) // 0 for January
+            add(Calendar.MONTH, +1)
+        }
+        return getMonth(c.time)
+    }
+
+    @StringRes
+    fun getWeekDayString(date: String, format: String?): Int {
+        return when (WeekDay.values()[getWeekDay(date, format)]) {
+            WeekDay.MON -> R.string.week_day_mon
+            WeekDay.TUE -> R.string.week_day_tue
+            WeekDay.WED -> R.string.week_day_wed
+            WeekDay.THU -> R.string.week_day_thu
+            WeekDay.FRI -> R.string.week_day_fri
+            WeekDay.SAT -> R.string.week_day_sat
+            WeekDay.SUN -> R.string.week_day_sun
+        }
+    }
+
+    fun getCurrentYear(): Int {
+        return getYear(Date(System.currentTimeMillis()))
+    }
+
+    fun getCurrentMonth(): Int {
+        return getMonth(Date(System.currentTimeMillis()))
+    }
+
+    fun getYear(date: Date): Int {
+        val c = Calendar.getInstance().apply {
+            time = date
+        }
+        return c[Calendar.YEAR]
+    }
+
+    fun getYear(date: String, format: String?): Int {
+        return getYear(date.formatDate(format))
+    }
+
+    fun getMonth(date: Date): Int {
+        val c = Calendar.getInstance().apply {
+            time = date
+        }
+        return c[Calendar.MONTH] + 1
+    }
+
+    fun getMonth(date: String, format: String?): Int {
+        return getMonth(
+            date.formatDate(format)
+        )
+    }
+
+    fun getDay(date: Date): Int {
+        val c = Calendar.getInstance().apply {
+            time = date
+        }
+        return c[Calendar.DAY_OF_MONTH]
+    }
+
+    fun getDay(date: String, format: String?): Int {
+        return getDay(date.formatDate(format))
+    }
+
+    fun getWeekDay(date: Date?): Int {
+        val c = Calendar.getInstance().apply {
+            time = date
+        }
+        return c[Calendar.DAY_OF_WEEK]
+    }
+
+    fun getWeekDay(date: String, format: String?): Int {
+        return getWeekDay(date.formatDate(format))
+    }
+
+    fun Date.formatDate(formatStr: String?): String {
+        return SimpleDateFormat(formatStr ?: DEFAULT_FORMAT_DATE_WITHOUT_TIME).format(this)
+    }
+
+    fun String.formatDate(formatStr: String?): Date {
+        return SimpleDateFormat(formatStr ?: DEFAULT_FORMAT_DATE_WITHOUT_TIME).parse(this)
+    }
+
+}

--- a/feature/record/src/main/res/values/strings.xml
+++ b/feature/record/src/main/res/values/strings.xml
@@ -32,8 +32,9 @@
     <string name="record_drive_sub_title">추가로 주행을 기록하세요.</string>
     <string name="record_drive_input_date_title">주행 날짜</string>
     <string name="record_drive_input_date_hint">주행날짜 선택</string>
-    <string name="record_drive_input_mileage_title">주행 거리</string>
-    <string name="record_drive_input_mileage_hint">00km</string>
+    <string name="record_drive_distance_default">0</string>
+    <string name="record_drive_input_distance_title">주행 거리</string>
+    <string name="record_drive_input_distance_hint">00km</string>
     <string name="record_drive_show_previous_driving_history">이전 주행기록 보기</string>
     <string name="record_drive_save_dialog_content">해당 주행 기록을 저장하시면\n누적 기록에 추가됩니다.</string>
     <string name="record_drive_save_dialog_confirm_button">추가할게요</string>
@@ -77,4 +78,12 @@
     <string name="record_exit_dialog_content">작성 중인 글이 있어요\n정말 나가시겠어요?</string>
     <string name="record_exit_dialog_confirm_button_continue">이어서 쓰기</string>
     <string name="record_exit_dialog_dismiss_button_exit">괜찮아요</string>
+
+    <string name="week_day_mon">월</string>
+    <string name="week_day_tue">화</string>
+    <string name="week_day_wed">수</string>
+    <string name="week_day_thu">목</string>
+    <string name="week_day_fri">금</string>
+    <string name="week_day_sat">토</string>
+    <string name="week_day_sun">일</string>
 </resources>


### PR DESCRIPTION
주행기록 & 이전 주행기록 관리 화면 API 연동
- 기록하기 api, repository, model 추가
- `DatePickerDialog` 로 날짜 선택
- 주행기록, 이전 기록 화면에 API 연동



> 에러 처리는 아직 안했습니다. 


https://user-images.githubusercontent.com/118257826/229881575-e99eb48b-bcfb-454c-ab94-0825006376d0.mp4


